### PR TITLE
Added support for kernel 4.15

### DIFF
--- a/morse.c
+++ b/morse.c
@@ -1,3 +1,4 @@
+#include <linux/sched.h>
 #include <linux/module.h>
 #include <linux/kernel.h>
 #include <linux/init.h>


### PR DESCRIPTION
Fix for this error when compiling for kernel 4.15:
```In file included from /home/are/source/morse/morse.c:5:0:
./arch/x86/include/asm/uaccess.h: In function ‘set_fs’:
./arch/x86/include/asm/uaccess.h:32:9: error: dereferencing pointer to incomplete type ‘struct task_struct’
  current->thread.addr_limit = fs;
```